### PR TITLE
Add ECS Instance Role to monitor terraform

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -40,6 +40,42 @@ data "aws_ami" "ecs" {
 // RESOURCES ==============================================
 
 # Give our instance the set of permissions required to act as an ECS node.
+
+
+resource "aws_iam_role_policy" "role" {
+  name = "ecsInstanceRole"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeTags",
+                "ecs:CreateCluster",
+                "ecs:DeregisterContainerInstance",
+                "ecs:DiscoverPollEndpoint",
+                "ecs:Poll",
+                "ecs:RegisterContainerInstance",
+                "ecs:StartTelemetrySession",
+                "ecs:UpdateContainerInstancesState",
+                "ecs:Submit*",
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+
 resource "aws_iam_instance_profile" "monitor" {
   name = "profile-serratus-monitor"
   role = "ecsInstanceRole"

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -41,8 +41,7 @@ data "aws_ami" "ecs" {
 
 # Give our instance the set of permissions required to act as an ECS node.
 
-
-resource "aws_iam_role_policy" "role" {
+resource "aws_iam_role" "ecsInstanceRole" {
   name = "ecsInstanceRole"
 
   assume_role_policy = <<EOF
@@ -74,7 +73,6 @@ resource "aws_iam_role_policy" "role" {
 }
 EOF
 }
-
 
 resource "aws_iam_instance_profile" "monitor" {
   name = "profile-serratus-monitor"


### PR DESCRIPTION
Is this sufficient for adding the ECS Instance role to the monitor? I set it up as a resource in that file directly, perhaps a better approach would be to add this to the iam_roles/main.tf? The policy is copied from my aws console and working.