### PR TITLE
Usability Improvements to Scheduler #1

### DIFF
--- a/containers/serratus-prometheus/prometheus.yml
+++ b/containers/serratus-prometheus/prometheus.yml
@@ -15,6 +15,11 @@ scrape_configs:
       - refresh_interval: 60s
         region: us-east-1
         port: 9100
+    relabel_configs:
+      - source_labels: [__meta_ec2_instance_id]
+        target_label: instance
+      - source_labels: [__meta_ec2_tag_component]
+        target_label: autoscaling_group
 
   - job_name: 'scheduler'
     scrape_interval: 15s

--- a/containers/serratus-scheduler/Dockerfile
+++ b/containers/serratus-scheduler/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu
 RUN apt-get update -yq
 RUN apt-get install -yqq python3-pip
 
-RUN pip3 install flask sqlalchemy gunicorn prometheus_client
+RUN pip3 install flask sqlalchemy gunicorn prometheus_client boto3
 
 # Run Python in UTF-8 mode
 ENV FLASK_APP=flask_app

--- a/containers/serratus-scheduler/README.md
+++ b/containers/serratus-scheduler/README.md
@@ -50,4 +50,21 @@ Use this API to view the Prometheus metrics.  This is mainly used by our Grafana
 
 ### Start and End jobs
 
-We use POST to start jobs, and PUT to end jobs.  You can also use these APIs to manually override behaviours in the scheduler.  The general idea is to use `POST /jobs/<type>/` to start a job (ID is returned as part of the job and automatically marked as running), and `PUT /jobs/<type>/<id>` to change its state.
+We use POST to start jobs, and PUT to end jobs.  You can also use these APIs to manually override behaviours in the scheduler.  The general idea is to use `POST /jobs/<type>/` to start a job (ID is returned as part of the job and automatically marked as running), and `PUT /jobs/<type>/<id>` to change its state. For example
+
+#### Reset accession download
+This will reset the accession 54 to the "new" state.
+```
+curl -X POST "localhost:8000/jobs/split/54?state=new&N_paired=0&N_unpaired=0"
+```
+#### Reset a range of align blocks
+This will reset blocks 205-230 to the new state.
+```
+for BLOCK_ID in $(seq 205 230)
+do
+  curl -X POST -s "localhost:8000/jobs/align/$BLOCK_ID?state=new"
+done
+```
+
+
+

--- a/containers/serratus-scheduler/README.md
+++ b/containers/serratus-scheduler/README.md
@@ -1,0 +1,53 @@
+# Serratus Scheduler
+This is a scheduler written in Flask, which coordinates the actions of Serratus.
+
+## Development
+
+For local development, I recommend running it locally on your laptop, with the development server.  To do that, from the `serratus/containers` directory, run:
+
+    ./build_containers.sh serratus-scheduler
+    podman run -d --rm -p5000:5000 -v $(realpath serratus-scheduler/flask_app):/opt/flask_app:z --name scheduler serratus-scheduler flask run -p 5000
+
+This will run the development server using port 5000 on the local system.  `-v` tells podman to map your local development directory on top of the scheduler's files, so the development server will reload whenever you make a change to your local files.  You can check it's working by watching `podman logs -f scheduler` while making a change to any of the Python files under `serratus-scheduler/flask_app`.
+
+## API Calls
+
+### Scheduler Configuration
+
+Get the current server config:
+
+    GET /config
+
+Update configuratation values, from JSON input.
+
+    PUT /config
+
+For example `curl -T <(echo '{"GENOME": "cov1"}') localhost:8000/config` will update the genome name.
+
+### Add SraRunInfo.csv
+
+Send a csv file from SRA to the scheduler, this is the main way to tell Serratus to do work:
+
+    curl -T /path/to/sra_run_info.csv -X POST /jobs/add_sra_run_info/
+
+### View HTML Table
+
+This page shows a table view of all the jobs currently known to the scheduler.
+
+    GET /jobs/
+
+### Trigger scheduler to check the instance list
+
+This trigger uses Ec2DescribeInstances and checks the instance list against all jobs that are currently in a running state.  If the instance is missing (probably due to being terminated or shut down), it resets the job to its prior state.
+
+    PUT /jobs/clear_terminated
+
+### Get metrics
+
+Use this API to view the Prometheus metrics.  This is mainly used by our Grafana server to create beautiful plots.
+
+    GET /metrics
+
+### Start and End jobs
+
+We use POST to start jobs, and PUT to end jobs.  You can also use these APIs to manually override behaviours in the scheduler.  The general idea is to use `POST /jobs/<type>/` to start a job (ID is returned as part of the job and automatically marked as running), and `PUT /jobs/<type>/<id>` to change its state.

--- a/containers/serratus-scheduler/flask_app/__init__.py
+++ b/containers/serratus-scheduler/flask_app/__init__.py
@@ -1,8 +1,9 @@
 """Master job scheduler.  Listens for requests from workers and feeds
 them information about work that needs doing."""
 import os
+import json
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request, current_app, redirect, url_for
 
 from . import db, jobs, metrics
 
@@ -16,8 +17,15 @@ def create_app(test_config=None):
     gunicorn 'flask-app:create_app()'
     """
     app = Flask(__name__, instance_relative_config=True)
+    CONFIG_KEYS = ["CLEAR_INTERVAL", "GENOME", "ARGS_DL", "ARGS_ALIGN", "ARGS_MERGE", "AWS_REGION"]
     app.config.from_mapping(
-        DATABASE=os.path.join(app.instance_path, 'scheduler.sqlite')
+        DATABASE=os.path.join(app.instance_path, 'scheduler.sqlite'),
+        CLEAR_INTERVAL=300,
+        GENOME="cov1r",
+        ARGS_DL="",
+        ARGS_ALIGN="--very-sensitive-local",
+        ARGS_MERGE="",
+        AWS_REGION="us-east-1",
     )
 
     if test_config is None:
@@ -34,10 +42,24 @@ def create_app(test_config=None):
     def status():
         return jsonify({'status': 'up'})
 
+    @app.route('/config', methods=["GET", "PUT"])
+    def config():
+        if request.method == "PUT":
+            print(json.loads(request.data))
+            current_app.config.from_mapping(json.loads(request.data))
+
+        result = dict()
+        for key in CONFIG_KEYS:
+            result[key] = current_app.config.get(key)
+        return jsonify(result)
+
+    @app.route('/')
+    def root():
+        return redirect(url_for('jobs.show_jobs'))
+
     app.register_blueprint(db.bp)
     app.register_blueprint(jobs.bp)
     app.register_blueprint(metrics.bp)
     db.init_app(app)
 
     return app
-

--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -45,6 +45,26 @@ module "iam_role" {
   name   = "scheduler"
 }
 
+resource "aws_iam_role_policy" "scheduler" {
+  name = "DescribeInstances-scheduler"
+  role = module.iam_role.role.id
+
+  policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": [
+        "ec2:DescribeInstances"
+			],
+			"Effect": "Allow",
+			"Resource": "*"
+		}
+	]
+}
+EOF
+}
+
 // RESOURCES ##############################
 
 resource "aws_cloudwatch_log_group" "scheduler" {


### PR DESCRIPTION
First pass at some usability improvements to the scheduler, that seem to be working.  Mainly, you can now call `curl -X PUT localhost:8000/jobs/clear_terminated`, to reset any terminated jobs back to new.

Some other bits and bobs are included too.