### PR TITLE
Scale-in capability

### DIFF
--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -141,16 +141,12 @@ function main_loop {
 
                 echo $ASG_NAME
 
-                aws autoscaling describe-auto-scaling-groups \
+                ASG_CAP=$(aws autoscaling describe-auto-scaling-groups \
                   --region us-east-1 | \
                   jq --arg ASG_NAME "$ASG_NAME" \
-                  '.AutoScalingGroups[] | select(.AutoScalingGroupName==$ASG_NAME).DesiredCapacity'
+                  '.AutoScalingGroups[] | select(.AutoScalingGroupName==$ASG_NAME).DesiredCapacity') & wait
 
-
-                ((ASG_CAP=$(aws autoscaling describe-auto-scaling-groups \
-                  --region us-east-1 | \
-                  jq --arg ASG_NAME "$ASG_NAME" \
-                  '.AutoScalingGroups[] | select(.AutoScalingGroupName==$ASG_NAME).DesiredCapacity')-1)) & wait
+                ((ASG_CAP=$ASG_CAP-1)) || true
 
                 echo $ASG_CAP
                 export ASG_CAP

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -152,8 +152,10 @@ function main_loop {
             aws autoscaling set-desired-capacity \
               --region us-east-1 \
               --auto-scaling-group-name $ASG_NAME \
-              --desired-capacity $NEW_CAP \
-              --honor-cooldown & wait
+              --desired-capacity $NEW_CAP
+
+            aws terminate-instances \
+             --instance-ids $INSTANCE_ID
 
             exit 0
             ;;

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -11,7 +11,7 @@ if [ ! -x "$2" ]; then
 fi
 TYPE="$1"; shift
 
-if [ "$TYPE" -eq "merge" ]; then
+if [ "$TYPE" = "merge" ]; then
     # protect from termination
     touch running.merge
 fi
@@ -203,10 +203,7 @@ function kill_workers {
     for i in $(seq 1 "$WORKERS"); do
         kill -USR1 ${worker[i]} 2>/dev/null || true
     done
-
-    aws terminate-instances \
-      --instance-ids $INSTANCE_ID
-
+    
     exit 0
 }
 

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -140,7 +140,7 @@ function main_loop {
             ;;
           shutdown)
             echo "  $WORKER_ID - Shutdown State received."
-            rm -f scale.in.pro
+            rm -f scale.in.pro || true
 
             ASG_CAP=$(aws autoscaling describe-auto-scaling-groups \
               --region us-east-1 | \
@@ -149,10 +149,14 @@ function main_loop {
 
             ((NEW_CAP=$ASG_CAP-1))
 
+            echo "  Scaling-in $ASG_NAME to size $NEW_CAP"
+
             aws autoscaling set-desired-capacity \
               --region us-east-1 \
               --auto-scaling-group-name $ASG_NAME \
               --desired-capacity $NEW_CAP
+
+            echo "  Shutting down instance"
 
             aws terminate-instances \
              --instance-ids $INSTANCE_ID

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -56,7 +56,7 @@ function main_loop {
         fi
 
         # Maximum number of retry attempts reached
-        if [ $retry_count -gt 10 ]
+        if [ $retry_count -gt 3 ]
         then
             ACTION=shutdown
         fi
@@ -144,6 +144,8 @@ function main_loop {
                   jq --arg ASG_NAME "$ASG_NAME" \
                   '.AutoScalingGroups[] | select(.AutoScalingGroupName==$ASG_NAME).DesiredCapacity') & wait
 
+                echo $ASG_CAP $ASG_NAME
+
                 ((ASG_CAP=$ASG_CAP-1)) & wait
 
                 export ASG_CAP
@@ -192,7 +194,9 @@ for i in $(seq 1 "$WORKERS"); do
 done
 
 function kill_workers {
-    for i in $(seq 1 "$WORKERS"); do
+    #for i in $(seq 1 "$WORKERS"); do
+    for i in $(seq 1 1); do
+
         kill -USR1 ${worker[i]} 2>/dev/null || true
     done
 

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -98,10 +98,13 @@ function main_loop {
             fi
 
             # When all worker's are punched-out, scale-in pro
-            if ls running* 1> /dev/null 2>&1; then
+            if ls running* 1> /dev/null 2>&1
+            then
+            
                 ## Other worker is not checked out
                 retry_count=0
             elif [ -f scale.in.pro ]
+            then
                 echo "  Removing SCALE-IN protection"
                 # Turn off scale-in protection
                 aws autoscaling set-instance-protection \

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -191,9 +191,7 @@ export INSTANCE_ID ASG_NAME
 
 # Fire up main loop (SRA downloader)
 echo "Creating $WORKERS worker processes"
-#for i in $(seq 1 "$WORKERS"); do
-for i in $(seq 1 1); do
-
+for i in $(seq 1 "$WORKERS"); do
     main_loop "$i" "$@" & worker[i]=$!
 done
 

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-set -eu
+set -eux
 
 # Wrapper script to serratus-{dl,align-merge}.  This script provides looping,
 # multi-threading and also checks for spot termination.  If nodes are
@@ -103,7 +103,7 @@ function main_loop {
             
                 ## Other worker is not checked out
                 retry_count=0
-            elif [ -f scale.in.pro ]
+            elif [ -f "scale.in.pro" ]
             then
                 echo "  Removing SCALE-IN protection"
                 # Turn off scale-in protection
@@ -146,7 +146,7 @@ function main_loop {
             (
                 flock 200
 
-                if [ -f scale.in.pro ]; then
+                if [ -f "scale.in.pro" ]; then
                     rm -f scale.in.pro
                 fi
 
@@ -170,7 +170,7 @@ function main_loop {
                  --instance-ids $INSTANCE_ID
 
                 exit 0
-                
+
             ) 200> "$BASEDIR/.shutdown-lock"
            
             ;;
@@ -191,7 +191,7 @@ cd $BASEDIR
 
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 ASG_NAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" --region us-east-1 | jq -r '.Tags[] | select(.["Key"] | contains("aws:autoscaling:groupName")) | .Value')
-
+export INSTANCE_ID ASG_NAME
 
 # Fire up main loop (SRA downloader)
 echo "Creating $WORKERS worker processes"

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -144,7 +144,7 @@ function main_loop {
                 ASG_CAP=$(aws autoscaling describe-auto-scaling-groups \
                   --region us-east-1 | \
                   jq --arg ASG_NAME "$ASG_NAME" \
-                  '.AutoScalingGroups[] | select(.AutoScalingGroupName==$ASG_NAME).DesiredCapacity') & wait
+                  '.AutoScalingGroups[] | select(.AutoScalingGroupName==$ASG_NAME).DesiredCapacity')
 
                 ASG_CAP=$(expr "$ASG_CAP" - 1 || true)
 
@@ -159,7 +159,6 @@ function main_loop {
                   --desired-capacity $ASG_CAP & wait
 
                 echo "  Shutting down instance"
-
                 aws ec2 terminate-instances \
                  --region us-east-1 \
                  --instance-ids $INSTANCE_ID & wait

--- a/containers/worker.sh
+++ b/containers/worker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-set -eux
+set -eu
 
 # Wrapper script to serratus-{dl,align-merge}.  This script provides looping,
 # multi-threading and also checks for spot termination.  If nodes are
@@ -218,17 +218,17 @@ trap kill_workers TERM
 # spot-termination signal and shutdown in the last 10
 # seconds to maximize chance the job finishes.
 
-# METADATA=http://169.254.169.254/latest/meta-data
-# while true; do
-#     # Note: this URL returns an HTML 404 page when there is no action.  Use
-#     # "curl -f" to mitigate that.
-#     INSTANCE_ACTION=$(curl -fs $METADATA/spot/instance-action | jq -r .action)
-#     if [ "$INSTANCE_ACTION" == "terminate" ]; then
-#         echo "SPOT TERMINATION SIGNAL RECEIEVED."
-#         echo "Initiating shutdown procedures for all workers"
+METADATA=http://169.254.169.254/latest/meta-data
+while true; do
+    # Note: this URL returns an HTML 404 page when there is no action.  Use
+    # "curl -f" to mitigate that.
+    INSTANCE_ACTION=$(curl -fs $METADATA/spot/instance-action | jq -r .action)
+    if [ "$INSTANCE_ACTION" == "terminate" ]; then
+        echo "SPOT TERMINATION SIGNAL RECEIEVED."
+        echo "Initiating shutdown procedures for all workers"
 
-#         kill_workers
-#     fi
+        kill_workers
+    fi
 
-#     sleep 5
-# done
+    sleep 5
+done

--- a/terraform/iam_role/main.tf
+++ b/terraform/iam_role/main.tf
@@ -39,6 +39,7 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
+
 resource "aws_iam_role_policy" "cloudwatch" {
   name = "CloudWatchLogsCreate-${var.name}"
   role = aws_iam_role.role.id

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -168,7 +168,7 @@ module "merge" {
   // TODO: the credentials are not properly set-up to
   //       upload to serratus-public, requires a *Object policy
   //       on the bucket.
-  options            = "-k ${module.work_bucket.name} -b s3://serratus-public/out/tmp"
+  options            = "-k ${module.work_bucket.name} -b s3://serratus-public/out/200427_CoV_positve_ctrl"
 }
 
 // RESOURCES ##############################

--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -148,6 +148,26 @@ resource "aws_iam_role_policy" "ec2Describe" {
 EOF
 }
 
+resource "aws_iam_role_policy" "ec2Terminate" {
+  name = "TerminateEC2Instances-${var.image_name}"
+  role = module.iam_role.role.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Terminate*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy" "AdjustAutoScaling" {
   name = "AdjustAutoScaling-${var.image_name}"
   role = module.iam_role.role.id


### PR DESCRIPTION
Let me know what you think of this set up.

- Workers now will auto-shutdown after 10 consecutive scheduler wait/retry events to prevent idle. That is ~100 seconds.
- Shutdown will adjust the ASG DesiredCapacity -1 immediately prior to shutdown. There is a global 300s cooldown on ASG changes being enacted.
- Workers now have EC2 describe and Autoscaling adjustment permissions
- If a worker has a running process, it will enact "scale-in protection" on itself. When all workers are done on an instance, this is removed.

---

This still needs testing to confirm these functions work.