### PR TITLE
Scheduler autoscaling --- big changes don't pull unless you're ready

### DIFF
--- a/containers/serratus-scheduler/Dockerfile
+++ b/containers/serratus-scheduler/Dockerfile
@@ -14,7 +14,9 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /opt/
 ADD serratus-scheduler/flask_app/ ./flask_app
 
-RUN flask init-db
+# If something fails, `flask init-db` prints a usage message, not the error.
+# So run "flask --help" in that case which does print the error
+RUN flask init-db || (flask --help; false)
 
 # Do NOT enable multithreading here, as the underlying app is
 # thread-unsafe.

--- a/containers/serratus-scheduler/Dockerfile
+++ b/containers/serratus-scheduler/Dockerfile
@@ -7,7 +7,7 @@ RUN pip3 install flask sqlalchemy gunicorn prometheus_client boto3
 
 # Run Python in UTF-8 mode
 ENV FLASK_APP=flask_app
-ENV FLASK_ENV=development
+ENV FLASK_ENV=production
 ENV LANG=C.UTF-8
 ENV PYTHONUNBUFFERED=1
 

--- a/containers/serratus-scheduler/README.md
+++ b/containers/serratus-scheduler/README.md
@@ -10,19 +10,41 @@ For local development, I recommend running it locally on your laptop, with the d
 
 This will run the development server using port 5000 on the local system.  `-v` tells podman to map your local development directory on top of the scheduler's files, so the development server will reload whenever you make a change to your local files.  You can check it's working by watching `podman logs -f scheduler` while making a change to any of the Python files under `serratus-scheduler/flask_app`.
 
-## API Calls
+## API Calls (normal use)
 
 ### Scheduler Configuration
 
 Get the current server config:
 
-    GET /config
+    curl localhost:8000/config > serratus-config.json
 
-Update configuratation values, from JSON input.
+This will output a configuration JSON file, like the following:
 
-    PUT /config
+    {
+      "ALIGN_SCALING_CONSTANT": 0.001,
+      "ALIGN_SCALING_ENABLE": false,
+      "ALIGN_SCALING_MAX": 20,
+      "CLEAR_INTERVAL": 300,
+      "DL_SCALING_CONSTANT": 0.001,
+      "DL_SCALING_ENABLE": false,
+      "DL_SCALING_MAX": 10,
+      "GENOME": "cov2r",
+      "MERGE_SCALING_CONSTANT": 0.001,
+      "MERGE_SCALING_ENABLE": false,
+      "MERGE_SCALING_MAX": 2,
+      "SCALING_INTERVAL": 30
+    }
 
-For example `curl -T <(echo '{"GENOME": "cov1"}') localhost:8000/config` will update the genome name.
+Change these values to what you want, and then update the configuration with another `curl` call:
+
+    curl -T serratus-config.json localhost:8000/config
+
+Notes
+
+ * If you delete keys, they will keep their old values.
+ * There should be a comma on every line except the last one.
+ * Be careful with types.  true/false fields in particular must *not* be quoted.  In Python, non-null
+   strings like "false", "no", and "disabled" will all be converted to True.
 
 ### Add SraRunInfo.csv
 
@@ -36,11 +58,15 @@ This page shows a table view of all the jobs currently known to the scheduler.
 
     GET /jobs/
 
+## API Calls (development / debugging)
+
 ### Trigger scheduler to check the instance list
 
 This trigger uses Ec2DescribeInstances and checks the instance list against all jobs that are currently in a running state.  If the instance is missing (probably due to being terminated or shut down), it resets the job to its prior state.
 
     PUT /jobs/clear_terminated
+
+This will now happen automatically, and this request should no longer be needed.
 
 ### Get metrics
 

--- a/containers/serratus-scheduler/flask_app/__init__.py
+++ b/containers/serratus-scheduler/flask_app/__init__.py
@@ -17,15 +17,8 @@ def create_app(test_config=None):
     gunicorn 'flask-app:create_app()'
     """
     app = Flask(__name__, instance_relative_config=True)
-    CONFIG_KEYS = ["CLEAR_INTERVAL", "GENOME", "ARGS_DL", "ARGS_ALIGN", "ARGS_MERGE", "AWS_REGION"]
     app.config.from_mapping(
         DATABASE=os.path.join(app.instance_path, 'scheduler.sqlite'),
-        CLEAR_INTERVAL=300,
-        GENOME="cov2r",
-        ARGS_DL="",
-        ARGS_ALIGN="--very-sensitive-local",
-        ARGS_MERGE="",
-        AWS_REGION="us-east-1",
     )
 
     if test_config is None:
@@ -45,13 +38,8 @@ def create_app(test_config=None):
     @app.route('/config', methods=["GET", "PUT"])
     def config():
         if request.method == "PUT":
-            print(json.loads(request.data))
-            current_app.config.from_mapping(json.loads(request.data))
-
-        result = dict()
-        for key in CONFIG_KEYS:
-            result[key] = current_app.config.get(key)
-        return jsonify(result)
+            db.update_config(json.loads(request.data))
+        return jsonify(dict(db.get_config()))
 
     @app.route('/')
     def root():

--- a/containers/serratus-scheduler/flask_app/__init__.py
+++ b/containers/serratus-scheduler/flask_app/__init__.py
@@ -5,7 +5,7 @@ import json
 
 from flask import Flask, jsonify, request, current_app, redirect, url_for
 
-from . import db, jobs, metrics
+from . import db, jobs, metrics, cron
 
 def create_app(test_config=None):
     """Main entrypoint.  Run this program using:
@@ -19,6 +19,7 @@ def create_app(test_config=None):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_mapping(
         DATABASE=os.path.join(app.instance_path, 'scheduler.sqlite'),
+        AWS_REGION="us-east-1",
     )
 
     if test_config is None:
@@ -49,5 +50,7 @@ def create_app(test_config=None):
     app.register_blueprint(jobs.bp)
     app.register_blueprint(metrics.bp)
     db.init_app(app)
+
+    cron.register(app)
 
     return app

--- a/containers/serratus-scheduler/flask_app/cron.py
+++ b/containers/serratus-scheduler/flask_app/cron.py
@@ -1,0 +1,101 @@
+import os
+import time
+import math
+from multiprocessing import Process
+
+from sqlalchemy import or_
+import boto3
+
+from . import db, jobs
+
+def get_asg_name(autoscaling, pattern):
+    """Look through all available ASGs to find one matching a pattern"""
+    paginator = autoscaling.get_paginator("describe_auto_scaling_groups").paginate()
+    for page in paginator:
+        for asg in page["AutoScalingGroups"]:
+            name = asg["AutoScalingGroupName"]
+            if pattern in name:
+                return name
+    raise RuntimeError('No ASG named "{}"'.format(pattern))
+
+
+def set_asg_size(autoscaling, asg_name, constant, max_, num_jobs, name):
+    desired_size = min(max_, math.ceil(constant * num_jobs))
+    print("Adjusting {} ASG to {}".format(name, desired_size))
+    try:
+        autoscaling.set_desired_capacity(
+            AutoScalingGroupName=asg_name,
+            DesiredCapacity=desired_size,
+        )
+    except (autoscaling.exceptions.ScalingActivityInProgressFault,
+            autoscaling.exceptions.ResourceContentionFault) as e:
+        print("Error setting ASG size, {}".format(e))
+
+
+def adjust_autoscaling_loop(app):
+    autoscaling = boto3.client('autoscaling', region_name=app.config["AWS_REGION"])
+    dl_asg = get_asg_name(autoscaling, "serratus-dl")
+    align_asg = get_asg_name(autoscaling, "serratus-align")
+    merge_asg = get_asg_name(autoscaling, "serratus-merge")
+    while True:
+        with app.app_context():
+            config = dict(db.get_config())
+
+            session = db.get_session()
+            num_dl_jobs = session.query(db.Accession)\
+                .filter(or_(db.Accession.state == "new",
+                            db.Accession.state == "splitting"))\
+                .count()
+
+            num_align_jobs = session.query(db.Block)\
+                .filter(or_(db.Block.state == "new",
+                            db.Block.state == "aligning"))\
+                .count()
+
+            num_merge_jobs = session.query(db.Accession)\
+                .filter(or_(db.Accession.state == "merge_wait",
+                            db.Accession.state == "merging"))\
+                .count()
+
+        if config["DL_SCALING_ENABLE"]:
+            constant = float(config["DL_SCALING_CONSTANT"])
+            max_ = int(config["DL_SCALING_MAX"])
+            set_asg_size(
+                autoscaling, dl_asg, constant, max_, num_dl_jobs, "dl"
+            )
+        if config["ALIGN_SCALING_ENABLE"]:
+            constant = float(config["ALIGN_SCALING_CONSTANT"])
+            max_ = int(config["ALIGN_SCALING_MAX"])
+            set_asg_size(
+                autoscaling, align_asg, constant, max_, num_align_jobs, "align"
+            )
+        if config["MERGE_SCALING_ENABLE"]:
+            constant = float(config["MERGE_SCALING_CONSTANT"])
+            max_ = int(config["MERGE_SCALING_MAX"])
+            set_asg_size(
+                autoscaling, merge_asg, constant, max_, num_merge_jobs, "merge"
+            )
+
+        scale_interval = int(config["SCALING_INTERVAL"])
+        print("ajust_autoscaling() finished.  Running again in {} seconds".format(scale_interval))
+        time.sleep(scale_interval)
+
+
+def clean_terminated_jobs_loop(app):
+    while True:
+        print("clear_terminated_jobs() triggered by interval")
+        with app.app_context():
+            jobs.clear_terminated_jobs()
+            clear_interval = int(db.get_config_val("CLEAR_INTERVAL"))
+        print("clear_terminated_jobs() finished.  Running again in {} seconds"
+              .format(clear_interval))
+        time.sleep(clear_interval)
+
+
+def register(app):
+    # Prevent this scheduler from running two instances in debug mode.
+    # See https://stackoverflow.com/a/25519547 for details
+    if not app.debug or os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
+        print("Creating new process")
+        Process(target=clean_terminated_jobs_loop, args=(app,)).start()
+        Process(target=adjust_autoscaling_loop, args=(app,)).start()

--- a/containers/serratus-scheduler/flask_app/jobs.py
+++ b/containers/serratus-scheduler/flask_app/jobs.py
@@ -118,7 +118,7 @@ def start_split_job():
     session.commit()
 
     response['action'] = 'process'
-    response['split_args'] = current_app.config["ARGS_DL"]
+    response['split_args'] = db.get_config_val("DL_ARGS")
 
     # Send the response as JSON
     return jsonify(response)
@@ -236,8 +236,8 @@ def start_align_job():
     session.commit()
 
     # TODO Move these into the database
-    response['align_args'] = current_app.config["ARGS_ALIGN"]
-    response['genome'] = current_app.config["GENOME"]
+    response['align_args'] = db.get_config_val("ALIGN_ARGS")
+    response['genome'] = db.get_config_val("GENOME")
     response['action'] = "process"
 
     # Send the response as JSON
@@ -315,7 +315,7 @@ def start_merge_job():
     session.commit()
     response['action'] = 'process'
 
-    response['merge_args'] = current_app.config["ARGS_MERGE"]
+    response['merge_args'] = db.get_config_val("MERGE_ARGS")
 
     # Send the response as JSON
     return jsonify(response)

--- a/containers/serratus-scheduler/shutdown_now.json
+++ b/containers/serratus-scheduler/shutdown_now.json
@@ -1,0 +1,5 @@
+{
+  "ALIGN_SCALING_MAX": 0,
+  "DL_SCALING_MAX": 0,
+  "MERGE_SCALING_MAX": 0
+}

--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -55,7 +55,9 @@ resource "aws_iam_role_policy" "scheduler" {
 	"Statement": [
 		{
 			"Action": [
-        "ec2:DescribeInstances"
+        "ec2:DescribeInstances",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:DescribeAutoScalingGroups"
 			],
 			"Effect": "Allow",
 			"Resource": "*"


### PR DESCRIPTION
Automatically adjust `desired_capacity` based on the number of blocks available.  Default is 1/1000, and the maxes are all really tiny, but this can all be adjusted through the scheduler config.  See the readme for details.

If you set all the 3 `ENABLED` values to false, this will be disabled.  Also note the `MAX` values are very low.  The `CONSTANT` values are also in need of tuning.  They default to 0.001 for all 3 groups which is extremely conservative.