### PR TITLE
v0.1.4b hotfix

### DIFF
--- a/containers/serratus-align/serratus-align.sh
+++ b/containers/serratus-align/serratus-align.sh
@@ -2,7 +2,7 @@
 # ENTRYPOINT SCRIPT ===================
 # serrtaus-align
 # =====================================
-set -eux
+set -eu
 #
 # Base: serratus-aligner (0.1)
 # Amazon Linux 2 with Docker

--- a/containers/serratus-dl/run_dl-sra.sh
+++ b/containers/serratus-dl/run_dl-sra.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/bash
-set -eux
+set -eu
 # Max number of FQ reads to download per accession [100M reads]
 # ~ 20 GB max
 FQMAX=${FQMAX:-100000000}
 # 4*Max number of FQ reads to partition per fq-block [250K reads * 4 lines]
-BLOCKSIZE=${BLOCKSIZE:-1000000}
+BLOCKSIZE=${BLOCKSIZE:-4000000}
 BASEDIR=${BASEDIR:-.}
 
 while getopts n: FLAG; do

--- a/containers/serratus-dl/serratus-dl.sh
+++ b/containers/serratus-dl/serratus-dl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -eu
 # ENTRYPOINT SCRIPT ===================
 # serrtaus-dl
 # =====================================

--- a/containers/serratus-merge/run_merge.sh
+++ b/containers/serratus-merge/run_merge.sh
@@ -183,11 +183,11 @@ else
 @SQ\tSN:serratus\tLN:1337
   " header.sam
 
-  echo -e "@CO\t====SERRATUS.IO====" >> header.sam
-  echo -e "@CO\tThis sam header is modified to reduce filesize." >> header.sam
-  echo -e "@CO\tTo reconstitute the missing @SQ entries" >> header.sam
-  echo -e "@CO\tDownload the header this pan-genome (i.e. cov2r) from:" >> header.sam
-  echo -e "@CO\t  https://serratus-public.s3.amazonaws.com/seq/<GENOME>/dummy_header.sam" >> header.sam
+  #echo -e "@CO\t====SERRATUS.IO====" >> header.sam
+  #echo -e "@CO\tThis sam header is modified to reduce filesize." >> header.sam
+  #echo -e "@CO\tTo reconstitute the missing @SQ entries" >> header.sam
+  #echo -e "@CO\tDownload the header this pan-genome (i.e. cov2r) from:" >> header.sam
+  #echo -e "@CO\t  https://serratus-public.s3.amazonaws.com/seq/<GENOME>/dummy_header.sam" >> header.sam
 
   # Convert new header to bam (add EOF)
   #samtools view -b header.sam > header.bam

--- a/containers/serratus-merge/run_merge.sh
+++ b/containers/serratus-merge/run_merge.sh
@@ -175,13 +175,14 @@ else
   # (Only for non-sort option)
 
   # Extract header from first file
-  samtools view -H $(head -n1 bam.list) |
-  sed '/^@SQ/d' - > header.sam
+  #samtools view -H $(head -n1 bam.list) |
+  #sed '/^@SQ/d' - > header.sam
+  samtools view -H $(head -n1 bam.list) > header.sam
 
   # Insert dummy SQ to make file 'intact'
-  sed -i "1a\
-@SQ\tSN:serratus\tLN:1337
-  " header.sam
+  #sed -i "1a\
+#@SQ\tSN:serratus\tLN:1337
+  #" header.sam
 
   #echo -e "@CO\t====SERRATUS.IO====" >> header.sam
   #echo -e "@CO\tThis sam header is modified to reduce filesize." >> header.sam


### PR DESCRIPTION
### Notes on hotfix
- Better aws API handling for scale-in protection
- Remove header modifications in output bam files to make files easier to work with (but bigger)
- Change default block size to 1 million reads per block to decrease cross-node i/o
- Changed `set -eux` to `set -eu` to reduce unnecessary info going to Cloudwatch logs 