### PR TITLE
Add indices to frequently queried columns in the scheduler.

### DIFF
--- a/containers/serratus-scheduler/flask_app/db.py
+++ b/containers/serratus-scheduler/flask_app/db.py
@@ -28,7 +28,7 @@ class Accession(Base, Dicter):
     __tablename__ = 'acc'
 
     acc_id = Column(Integer, primary_key=True)
-    state = Column(Enum(name='state', *ACC_STATES))
+    state = Column(Enum(name='state', *ACC_STATES), index=True)
 
     contains_paired = Column(Boolean)
     contains_unpaired = Column(Boolean)
@@ -49,7 +49,7 @@ class Block(Base, Dicter):
     __tablename__ = 'blocks'
 
     block_id = Column(Integer, primary_key=True)
-    state = Column(Enum(name='state', *BLOCK_STATES))
+    state = Column(Enum(name='state', *BLOCK_STATES), index=True)
     acc_id = Column(Integer, ForeignKey('acc.acc_id'))
     n = Column(Integer)
 


### PR DESCRIPTION
Add indices to the "state" columns.  This is a quick performance update.  Not sure if this is actually a hotspot in the scheduler, but it improves performance quite a lot on the database queries, so it should have a positive effect on performance.