### PR TITLE
:whale: Use the simplest possible multi-stage builds

### DIFF
--- a/containers/serratus-align/Dockerfile
+++ b/containers/serratus-align/Dockerfile
@@ -70,6 +70,10 @@ WORKDIR /home/serratus
 COPY worker.sh ./
 COPY serratus-align/*sh ./
 
+FROM amazonlinux:2 AS runtime
+
+COPY --from=build_base / /
+
 #==========================================================
 # ENTRYPOINT ==============================================
 #==========================================================

--- a/containers/serratus-dl/Dockerfile
+++ b/containers/serratus-dl/Dockerfile
@@ -67,6 +67,10 @@ WORKDIR /home/serratus
 COPY worker.sh ./
 COPY serratus-dl/*sh ./
 
+FROM amazonlinux:2 AS runtime
+
+COPY --from=build_base / /
+
 #==========================================================
 # ENTRYPOINT ==============================================
 #==========================================================

--- a/containers/serratus-dl/Dockerfile
+++ b/containers/serratus-dl/Dockerfile
@@ -14,13 +14,6 @@ ENV GDCVERSION='1.5.0'
 ENV BVVERSION='0.1'
 #ENV PICARDVERSION='2.22.0'
 
-# Additional Metadata
-LABEL container.type=${TYPE}
-LABEL container.version=${VERSION}
-LABEL container.description="serratus: downloader and fq-splitter"
-LABEL software.license="GPLv3"
-LABEL tags="aws-cli, samtools, sra-toolkit, bvfilter"
-
 #==========================================================
 # Dependencies ============================================
 #==========================================================
@@ -68,6 +61,17 @@ COPY worker.sh ./
 COPY serratus-dl/*sh ./
 
 FROM amazonlinux:2 AS runtime
+
+# Additional Metadata
+LABEL container.type=${TYPE}
+LABEL container.version=${VERSION}
+LABEL container.description="serratus: downloader and fq-splitter"
+LABEL software.license="GPLv3"
+LABEL tags="aws-cli, samtools, sra-toolkit, bvfilter"
+
+# set path for sra toolkit
+ENV SRATOOLKITVERSION='2.10.4'
+ENV PATH "$PATH:/opt/sratoolkit.${SRATOOLKITVERSION}-centos_linux64/bin"
 
 COPY --from=build_base / /
 

--- a/containers/serratus-merge/Dockerfile
+++ b/containers/serratus-merge/Dockerfile
@@ -37,6 +37,10 @@ COPY serratus-merge/*py ./
 #RUN curl https://serratus-public.s3.amazonaws.com/var/taxid_desc.txt > \
 #  ./taxid_desc.txt
 
+FROM amazonlinux:2 AS runtime
+
+COPY --from=build_base / /
+
 #==========================================================
 # ENTRYPOINT ==============================================
 #==========================================================


### PR DESCRIPTION
This PR won't remove any extra files from the final images, but it does remove the layer cache.  The builds will take longer, because we're copying the whole FS across. However, the multi-stage images are about half the size of the builder stage across the board:

<img width="766" alt="image" src="https://user-images.githubusercontent.com/4185637/82711831-c6c89f00-9c43-11ea-993f-82fadd1c6e0f.png">
