### PR TITLE
🐳 extract minimum required files for dl into final stage

### DIFF
--- a/containers/serratus-dl/Dockerfile
+++ b/containers/serratus-dl/Dockerfile
@@ -10,15 +10,15 @@ ARG VERSION='0.1.4'
 # Software Information
 # ENV SAMTOOLSVERSION='1.10'  # from serratus-base
 ENV SRATOOLKITVERSION='2.10.4'
-ENV GDCVERSION='1.5.0'
-ENV BVVERSION='0.1'
+#ENV GDCVERSION='1.5.0'
+#ENV BVVERSION='0.1'
 #ENV PICARDVERSION='2.22.0'
 
 #==========================================================
 # Dependencies ============================================
 #==========================================================
 # Libraries for serratus-downloader scripts
-RUN yum -y install pigz
+#RUN yum -y install pigz
 
 # EPEL + Parallel
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -45,7 +45,7 @@ RUN wget --quiet https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/${SRATOOLKITVERSION}
 #    mv gdc-client /usr/local/bin/
 
 # BVFILTER =====================================
-COPY bin/bvfilter /usr/local/bin/
+#COPY bin/bvfilter /usr/local/bin/
 
 #==========================================================
 # Serratus Initialize =====================================
@@ -62,7 +62,7 @@ LABEL container.type=${TYPE}
 LABEL container.version=${VERSION}
 LABEL container.description="serratus: downloader and fq-splitter"
 LABEL software.license="GPLv3"
-LABEL tags="aws-cli, samtools, sra-toolkit, bvfilter"
+LABEL tags="aws-cli, sra-toolkit"
 
 # aws cli, plus dependencies
 RUN yum -y install ps jq python3 perl \
@@ -78,6 +78,7 @@ COPY --from=build_base /opt/sratools/ /usr/local/bin/
 
 # parallel
 COPY --from=build_base /usr/bin/parallel /usr/bin/
+# echo will cite | parallel --citation 1>/dev/null 2>/dev/null
 
 WORKDIR /home/serratus
 COPY worker.sh ./

--- a/containers/serratus-dl/Dockerfile
+++ b/containers/serratus-dl/Dockerfile
@@ -70,7 +70,8 @@ RUN yum -y install ps jq python3 perl \
  && curl -O https://bootstrap.pypa.io/get-pip.py \
  && python3 get-pip.py \
  && rm get-pip.py \
- && pip install boto3 awscli
+ && pip install boto3 awscli \
+ && yum clean all
 
 # sratools
 COPY --from=build_base /root/.ncbi /root/.ncbi

--- a/containers/serratus-dl/Dockerfile
+++ b/containers/serratus-dl/Dockerfile
@@ -55,10 +55,6 @@ COPY bin/bvfilter /usr/local/bin/
 COPY serratus-dl/VDB_user-settings.mkfg /root/.ncbi/user-settings.mkfg
 RUN mkdir -p /root/.ncbi; vdb-config --report-cloud-identity yes
 
-WORKDIR /home/serratus
-COPY worker.sh ./
-COPY serratus-dl/*sh ./
-
 FROM amazonlinux:2 AS runtime
 
 # Additional Metadata
@@ -68,22 +64,24 @@ LABEL container.description="serratus: downloader and fq-splitter"
 LABEL software.license="GPLv3"
 LABEL tags="aws-cli, samtools, sra-toolkit, bvfilter"
 
-#samtools
-COPY --from=build_base /usr/local/bin/samtools /usr/local/bin/
-
-#awscli and python deps
-COPY --from=build_base /usr/local/lib/python3.* /usr/local/lib/
-COPY --from=build_base /usr/local/lib64/python3.* /usr/local/lib64/
-COPY --from=build_base /usr/bin/python3* /usr/bin/
-COPY --from=build_base /usr/local/bin/aws /usr/local/bin/
-COPY --from=build_base /usr/local/bin/pip /usr/local/bin/
-
-# bvfilter
-COPY --from=build_base /usr/local/bin/bvfilter /usr/local/bin/
+# aws cli, plus dependencies
+RUN yum -y install ps jq python3 perl \
+ && alias python=python3 \
+ && curl -O https://bootstrap.pypa.io/get-pip.py \
+ && python3 get-pip.py \
+ && rm get-pip.py \
+ && pip install boto3 awscli
 
 # sratools
 COPY --from=build_base /root/.ncbi /root/.ncbi
 COPY --from=build_base /opt/sratools/ /usr/local/bin/
+
+# parallel
+COPY --from=build_base /usr/bin/parallel /usr/bin/
+
+WORKDIR /home/serratus
+COPY worker.sh ./
+COPY serratus-dl/*sh ./
 
 #==========================================================
 # ENTRYPOINT ==============================================

--- a/containers/serratus-dl/Dockerfile
+++ b/containers/serratus-dl/Dockerfile
@@ -31,13 +31,12 @@ RUN yum install -y parallel procps-ng; echo will cite | parallel --citation 1>/d
 RUN wget --quiet https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/${SRATOOLKITVERSION}/sratoolkit.${SRATOOLKITVERSION}-centos_linux64.tar.gz &&\
     tar xzf sratoolkit.${SRATOOLKITVERSION}-centos_linux64.tar.gz &&\
     rm -f sratoolkit.${SRATOOLKITVERSION}-centos_linux64.tar.gz &&\
-    mv ./sratoolkit.${SRATOOLKITVERSION}-centos_linux64 /opt &&\
-    echo -e "export PATH=/opt/sratoolkit.${SRATOOLKITVERSION}-centos_linux64/bin:\$PATH" >\
-            /etc/profile.d/sratoolkit.sh &&\
-    chmod 755 /etc/profile.d/sratoolkit.sh &&\
+    mkdir -p /opt/sratools &&\
+    # Keep sratools grouped together, so its easy to copy them all out into the runtime
+    mv ./sratoolkit.${SRATOOLKITVERSION}-centos_linux64/bin/{vdb-config*,prefetch*,fastq-dump*,fasterq-dump*,sratools*} /opt/sratools &&\
+    # Install into /usr/local/bin for the rest of the build
+    cp -r /opt/sratools/* /usr/local/bin &&\
     mkdir /etc/ncbi
-
-ENV PATH "$PATH:/opt/sratoolkit.${SRATOOLKITVERSION}-centos_linux64/bin"
 
 # GDC-CLIENT ===================================
 # RUN wget --quiet https://gdc.cancer.gov/system/files/authenticated%20user/0/gdc-client_v${GDCVERSION}_Ubuntu_x64.zip &&\
@@ -69,11 +68,22 @@ LABEL container.description="serratus: downloader and fq-splitter"
 LABEL software.license="GPLv3"
 LABEL tags="aws-cli, samtools, sra-toolkit, bvfilter"
 
-# set path for sra toolkit
-ENV SRATOOLKITVERSION='2.10.4'
-ENV PATH "$PATH:/opt/sratoolkit.${SRATOOLKITVERSION}-centos_linux64/bin"
+#samtools
+COPY --from=build_base /usr/local/bin/samtools /usr/local/bin/
 
-COPY --from=build_base / /
+#awscli and python deps
+COPY --from=build_base /usr/local/lib/python3.* /usr/local/lib/
+COPY --from=build_base /usr/local/lib64/python3.* /usr/local/lib64/
+COPY --from=build_base /usr/bin/python3* /usr/bin/
+COPY --from=build_base /usr/local/bin/aws /usr/local/bin/
+COPY --from=build_base /usr/local/bin/pip /usr/local/bin/
+
+# bvfilter
+COPY --from=build_base /usr/local/bin/bvfilter /usr/local/bin/
+
+# sratools
+COPY --from=build_base /root/.ncbi /root/.ncbi
+COPY --from=build_base /opt/sratools/ /usr/local/bin/
 
 #==========================================================
 # ENTRYPOINT ==============================================


### PR DESCRIPTION
This PR refines the multi-stage build for `serratus-dl`. Instead of copying the entire filesystem, we copy just the binaries that we've built in the build stage. Additionally, we use the package manager to install tool dependencies. It builds a 547MB image on my machine.

<img width="749" alt="image" src="https://user-images.githubusercontent.com/4185637/82719795-15d5fa80-9c6b-11ea-8c0f-ec20e7bae67d.png">
