### PR TITLE
🐳 Copy minimal dependencies for merge

### DIFF
--- a/containers/serratus-merge/Dockerfile
+++ b/containers/serratus-merge/Dockerfile
@@ -10,12 +10,6 @@ ARG VERSION='0.1.4'
 # Software Information
 # ENV SAMTOOLSVERSION='1.10'  # from serratus-base
 
-# Additional Metadata
-LABEL container.type=${TYPE}
-LABEL container.version=${VERSION}
-LABEL container.description="serratus: alignment container"
-LABEL software.license="GPLv3"
-LABEL tags="aws-cli, samtools"
 
 #==========================================================
 # Dependencies ============================================
@@ -32,9 +26,31 @@ LABEL tags="aws-cli, samtools"
 
 FROM amazonlinux:2 AS runtime
 
+# Additional Metadata
+LABEL container.type=${TYPE}
+LABEL container.version=${VERSION}
+LABEL container.description="serratus: alignment container"
+LABEL software.license="GPLv3"
+LABEL tags="aws-cli, samtools"
+
+# Environment setup
 ENV BASEDIR=/home/serratus
 
-COPY --from=build_base / /
+# aws cli, plus dependencies
+# -merge has its own python dependency, so do a full python/pip install
+RUN yum -y install python3 perl \
+ && alias python=python3 \
+ && curl -O https://bootstrap.pypa.io/get-pip.py \
+ && python3 get-pip.py \
+ && rm get-pip.py \
+ && pip install boto3 awscli \
+ && yum clean all \
+#   aws configuration
+ && aws configure set default.s3.multipart_threshold 4GB \
+ && aws configure set default.s3.multipart_chunksize 4GB
+
+# samtools
+COPY --from=build_base /usr/local/bin/samtools /usr/local/bin/
 
 #==========================================================
 # Serratus Initialize =====================================

--- a/containers/serratus-merge/serratus-merge.sh
+++ b/containers/serratus-merge/serratus-merge.sh
@@ -191,8 +191,8 @@ WORKDIR=$BASEDIR/work/$RUNID
 mkdir -p $WORKDIR; cd $WORKDIR
 
 # Download pan-genome summary data
-if [ ! -f $BASEDIR/"$GENOME".sumzer.tsv ]; then
-  aws s3 cp s3://serratus-public/seq/"$GENOME"/"$GENOME".sumzer.tsv $BASEDIR/
+if [ ! -f "$BASEDIR/$GENOME.sumzer.tsv" ]; then
+  aws s3 cp "s3://serratus-public/seq/$GENOME/$GENOME.sumzer.tsv" $BASEDIR/
 fi
 
 cp $BASEDIR/"$GENOME".sumzer.tsv $WORKDIR/ # copy summarizer tables into runid


### PR DESCRIPTION
* Install python/pip/aws cli instead of using the installer, because `-merge` needs to run `serratus_summarizer.py`
* Copy over samtools
* Clean up some random quoting in `run_merge.sh`

I wasn't able to get anything to run, because I couldn't find a valid configuration for the scripts. I kept running into an error about a missing `.sumzer.tsv`. It looks like that's built from the `$JOB_JSON`, so I tried setting it to `export JOB_JSON='{"genome":"flom2"}'`, because I found a `flom2.sumzer.tsv` in the right place in `s3`, but it still didn't work.

If anyone has a suggestion I can run from my machine to verify I can keep working on it, or if its easier you guys could run/verify.

This one will bring merge in line with `-align` and `-dl`
<img width="745" alt="image" src="https://user-images.githubusercontent.com/4185637/82757146-d3f8a180-9d9b-11ea-81ab-42878c006824.png">
