### PR TITLE
:mute: :whale: No worker logs in ECS

### DIFF
--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -255,7 +255,7 @@ resource "aws_launch_configuration" "worker" {
               instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
               hostname ${var.image_name}-$instance_id
               docker run -d \
-                --log-driver=none
+                --log-driver=none \
                 --name ${var.image_name} \
                 -e SCHEDULER=${var.scheduler} \
                 ${var.dockerhub_account}/${var.image_name} \

--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -255,15 +255,7 @@ resource "aws_launch_configuration" "worker" {
               instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
               hostname ${var.image_name}-$instance_id
               docker run -d \
-              // Comment out to write logs to cloudwatch
                 --log-driver=none
-              // Un-comment to write logs to cloudwatch
-              /* 
-                --log-driver=awslogs \
-                --log-opt awslogs-region="${data.aws_region.current.name}" \
-                --log-opt awslogs-group="${aws_cloudwatch_log_group.g.name}" \
-                --log-opt awslogs-stream="$instance_id" \
-              */
                 --name ${var.image_name} \
                 -e SCHEDULER=${var.scheduler} \
                 ${var.dockerhub_account}/${var.image_name} \

--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -255,10 +255,15 @@ resource "aws_launch_configuration" "worker" {
               instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
               hostname ${var.image_name}-$instance_id
               docker run -d \
+              // Comment out to write logs to cloudwatch
+                --log-driver=none
+              // Un-comment to write logs to cloudwatch
+              /* 
                 --log-driver=awslogs \
                 --log-opt awslogs-region="${data.aws_region.current.name}" \
                 --log-opt awslogs-group="${aws_cloudwatch_log_group.g.name}" \
                 --log-opt awslogs-stream="$instance_id" \
+              */
                 --name ${var.image_name} \
                 -e SCHEDULER=${var.scheduler} \
                 ${var.dockerhub_account}/${var.image_name} \


### PR DESCRIPTION
Uses the `--log-driver=none` to disable all logging from worker containers in ECS. For debugging runs, the comments can be swapped to re-enable the cloudwatch driver.

I think this will be the easiest solution to the issue with expensive logs. I haven't been able to get a real serratus environment spun up in AWS yet, so I haven't tested it. If one of you guys could apply this script and launch a container to make sure it doesn't say anything that would be great.

I'll try to get serratus running in my AWS account to test this out, but it might take me a few days.