### PR TITLE
Scheduler scaling

### DIFF
--- a/containers/serratus-scheduler/flask_app/db.py
+++ b/containers/serratus-scheduler/flask_app/db.py
@@ -172,6 +172,12 @@ def enable_pg_stat_statements():
     with get_engine().connect() as con:
         con.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements;")
 
+        # Allow an index-only scan to find non-mergeable accessions.  This
+        # index is used by the start_merge_job subquery.
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS block_state_idx ON blocks (state) INCLUDE (acc_id);"
+        )
+
 
 def init_db(reset=False):
     """Clear the existing data and create new tables."""

--- a/containers/serratus-scheduler/flask_app/metrics.py
+++ b/containers/serratus-scheduler/flask_app/metrics.py
@@ -28,8 +28,11 @@ def update_counts():
     for state, count in acc_bystate:
         acc_state_gauge.labels(state).set(count)
 
+    # Avoid "done" blocks, as this can involve counting a very large number
+    # of rows.
     block_bystate = (
         session.query(db.Block.state, func.count(db.Block.state))
+        .filter(db.Block.state != "done")
         .group_by(db.Block.state)
         .all()
     )


### PR DESCRIPTION
Quick gut-based fixes for the scheduler scaling problem.
 - Added the index we've been using to the database initialization
 - Stop querying "done" blocks from the monitor.  We have to perform a sequential scan of the "done" blocks to produce the metric and it's possible that's killing our cache.

The latter change will remove "done" blocks from Grafana, which will break the speed meter.  I do have a plan in place to get those metrics back.