### PR TITLE
Save metrics data to an external database between runs.

### DIFF
--- a/containers/serratus-prometheus/prometheus.yml
+++ b/containers/serratus-prometheus/prometheus.yml
@@ -1,6 +1,11 @@
 global:
   scrape_interval: 15s
 
+remote_write:
+  - url: "http://metrics:9201/write"
+remote_read:
+  - url: "http://metrics:9201/read"
+
 scrape_configs:
   - job_name: 'prometheus'
     scrape_interval: 15s

--- a/containers/serratus-prometheus/prometheus.yml
+++ b/containers/serratus-prometheus/prometheus.yml
@@ -3,8 +3,8 @@ global:
 
 remote_write:
   - url: "http://metrics:9201/write"
-remote_read:
-  - url: "http://metrics:9201/read"
+#remote_read:
+#  - url: "http://metrics:9201/read"
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/terraform/main/terraform.tfvars
+++ b/terraform/main/terraform.tfvars
@@ -3,17 +3,21 @@
 ///////////////////////////////////////////////////////////
 
 // AWS User Settings ##############################
-key_name          = "serratus"
+key_name = "serratus"
 
 // ensure your IAM has permissions
 // to write to the output bucket
 // (no terminal slash)
-output_bucket     = "s3://ur_bucket_name/out/yymmdd_ii"
+output_bucket = "s3://ur_bucket_name/out/yymmdd_ii"
 
 // Local Settings ##############################
 // <Your IP>/32. Use `curl ipecho.net/plain; echo`
-dev_cidrs         = ["173.181.15.58/32", "75.155.242.64/32"]
+dev_cidrs = ["173.181.15.58/32", "75.155.242.64/32"]
 
 // Docker Hub ##############################
 // Account to upload container images to or use defaults ["serratusbio"]
 dockerhub_account = "serratusbio"
+
+// Long-term metrics server.  Point to a system that exposes the Prometheus
+// remote-read / remote-write endpoints on port 9201, such as Timescale.
+metrics_ip = "172.31.60.78"

--- a/terraform/monitoring/monitor-task-definition.json
+++ b/terraform/monitoring/monitor-task-definition.json
@@ -14,6 +14,10 @@
       {
         "hostname": "scheduler",
         "ipAddress": "${sched_ip}"
+      },
+      {
+        "hostname": "metrics",
+        "ipAddress": "${metrics_ip}"
       }
     ],
     "ulimits": [{


### PR DESCRIPTION
This connects Prometheus to an external timescaledb instance, which stores metrics between runs, allowing us to debug stuff after running `terraform destroy`.