### PR TITLE
Scheduler scaling

### DIFF
--- a/containers/serratus-grafana/dashboards/Postgres Statement Stats.json
+++ b/containers/serratus-grafana/dashboards/Postgres Statement Stats.json
@@ -1,0 +1,443 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": 4,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_total_time_seconds[1m]) / rate(pg_stat_statements_calls[1m]) * 1000",
+          "interval": "",
+          "legendFormat": "{{queryid}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Query Time [ms]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:616",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:617",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_total_time_seconds[1m])",
+          "interval": "",
+          "legendFormat": "{{queryid}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Query Time [s/s]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:669",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:670",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(pg_stat_statements_calls[1m])",
+          "interval": "",
+          "legendFormat": "{{queryid}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Statement Count [per second]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:616",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:617",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "pg_locks_count",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Locks",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1387",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1388",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Postgres Statement Stats",
+  "uid": "QbaRlriMz",
+  "version": 4
+}

--- a/containers/serratus-grafana/dashboards/Serratus Scheduler.json
+++ b/containers/serratus-grafana/dashboards/Serratus Scheduler.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 1,
-  "iteration": 1592096748370,
+  "id": 2,
+  "iteration": 1592122343709,
   "links": [],
   "panels": [
     {
@@ -35,7 +35,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 0,
         "y": 0
@@ -131,7 +131,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 12,
         "y": 0
@@ -227,10 +227,10 @@
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 0,
-        "y": 8
+        "y": 6
       },
       "hiddenSeries": false,
       "id": 2,
@@ -364,10 +364,10 @@
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 8,
-        "y": 8
+        "y": 6
       },
       "hiddenSeries": false,
       "id": 12,
@@ -393,7 +393,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1592096748370,
+      "repeatIteration": 1592122343709,
       "repeatPanelId": 2,
       "scopedVars": {
         "asg": {
@@ -503,10 +503,10 @@
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
         "x": 16,
-        "y": 8
+        "y": 6
       },
       "hiddenSeries": false,
       "id": 13,
@@ -532,7 +532,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1592096748370,
+      "repeatIteration": 1592122343709,
       "repeatPanelId": 2,
       "scopedVars": {
         "asg": {
@@ -643,9 +643,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 16
+        "y": 13
       },
       "hiddenSeries": false,
       "id": 4,
@@ -674,7 +674,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(scheduler_request_latency_seconds_sum[1m]) / rate(scheduler_request_latency_seconds_count[1m])",
+          "expr": "rate(scheduler_request_latency_seconds_sum[1m]) / rate(scheduler_request_latency_seconds_count[1m]) * 1000.",
           "interval": "",
           "legendFormat": "{{method}} {{endpoint}}",
           "refId": "A"
@@ -684,7 +684,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Average Request Latency [seconds]",
+      "title": "Average Request Latency [ms]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -705,7 +705,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -724,41 +724,6 @@
       }
     },
     {
-      "alert": {
-        "alertRuleTags": {},
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                0.8
-              ],
-              "type": "gt"
-            },
-            "operator": {
-              "type": "and"
-            },
-            "query": {
-              "params": [
-                "A",
-                "5m",
-                "now"
-              ]
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg"
-            },
-            "type": "query"
-          }
-        ],
-        "executionErrorState": "alerting",
-        "for": "5m",
-        "frequency": "1m",
-        "handler": 1,
-        "name": "Total Request Time [per second] alert",
-        "noDataState": "no_data",
-        "notifications": []
-      },
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -774,9 +739,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
+        "w": 8,
+        "x": 8,
+        "y": 13
       },
       "hiddenSeries": false,
       "id": 6,
@@ -811,19 +776,11 @@
           "refId": "A"
         }
       ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 0.8
-        }
-      ],
+      "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Total Request Time [per second]",
+      "title": "Total Request Time [s/s]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -844,7 +801,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -878,9 +835,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
+        "w": 8,
+        "x": 16,
+        "y": 13
       },
       "hiddenSeries": false,
       "id": 7,
@@ -940,7 +897,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1020,7 +977,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -1040,5 +997,5 @@
   "timezone": "",
   "title": "Serratus Scheduler",
   "uid": "t_HhOqeZk",
-  "version": 1
+  "version": 6
 }

--- a/containers/serratus-grafana/dashboards/Serratus.json
+++ b/containers/serratus-grafana/dashboards/Serratus.json
@@ -17,9 +17,190 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 3,
-  "iteration": 1592104545297,
+  "iteration": 1592157979017,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "rate(scheduler_done_items_total{kind=\"dl\"}[$interval]) * 3600",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DLed / hr",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "rate(scheduler_done_items_total{kind=\"merge\"}[$interval]) * 3600",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Merged / hr",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "rate(scheduler_done_items_total{kind=\"align\"}[$interval]) * 3600",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Aligned / hr",
+      "type": "stat"
+    },
     {
       "datasource": null,
       "fieldConfig": {
@@ -46,7 +227,7 @@
         "h": 3,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 18,
       "options": {
@@ -104,7 +285,7 @@
         "h": 3,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 3
       },
       "id": 16,
       "links": [],
@@ -138,181 +319,6 @@
       "type": "stat"
     },
     {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": null
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 3
-      },
-      "id": 34,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "pluginVersion": "7.0.3",
-      "targets": [
-        {
-          "expr": "rate(scheduler_done_items_total{kind=\"dl\"}[$interval]) * 3600",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "DLed / Hour",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": null
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 3
-      },
-      "id": 31,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "pluginVersion": "7.0.3",
-      "targets": [
-        {
-          "expr": "rate(scheduler_done_items_total{kind=\"merge\"}[$interval]) * 3600",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Merged / Hour",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": null
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 3
-      },
-      "id": 35,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        }
-      },
-      "pluginVersion": "7.0.3",
-      "targets": [
-        {
-          "expr": "rate(scheduler_done_items_total{kind=\"align\"}[$interval]) * 3600",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Aligned / Hour",
-      "type": "stat"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -330,7 +336,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 6
       },
       "hiddenSeries": false,
       "id": 8,
@@ -426,7 +432,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 6
       },
       "hiddenSeries": false,
       "id": 10,
@@ -505,6 +511,180 @@
       }
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "count (node_cpu_seconds_total{job=\"ec2\",mode=\"user\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total vCPUs",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(node_memory_MemTotal_bytes{job=\"ec2\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 39,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total Disk",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -522,7 +702,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 2,
@@ -562,7 +742,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Used Percent",
+      "title": "Average CPU Used Percent",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -619,7 +799,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 15
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 4,
@@ -648,7 +828,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (autoscaling_group) ( 1 - (node_memory_MemAvailable_bytes{instance=~\"$instance\"}/node_memory_MemTotal_bytes{instance=~\"$instance\"} ) )",
+          "expr": "max by (autoscaling_group) ( 1 - (node_memory_MemAvailable_bytes{instance=~\"$instance\"}/node_memory_MemTotal_bytes{instance=~\"$instance\"} ) )",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{autoscaling_group}}",
@@ -659,7 +839,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Memory Used Percent",
+      "title": "Max Memory Used Percent",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -716,7 +896,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 15
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 6,
@@ -745,7 +925,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (autoscaling_group) (1- (node_filesystem_avail_bytes{instance=~\"$instance\"} / node_filesystem_size_bytes{instance=~\"$instance\"}))",
+          "expr": "max by (autoscaling_group) (1- (node_filesystem_avail_bytes{instance=~\"$instance\"} / node_filesystem_size_bytes{instance=~\"$instance\"}))",
           "interval": "",
           "legendFormat": "{{autoscaling_group}}",
           "refId": "A"
@@ -755,7 +935,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Disk Used Percent",
+      "title": "Max Disk Used Percent",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -802,7 +982,23 @@
       "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
         "overrides": []
       },
@@ -812,11 +1008,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 26,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
@@ -832,6 +1029,7 @@
         "dataLinks": []
       },
       "percentage": false,
+      "pluginVersion": "7.0.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -908,7 +1106,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 27,
@@ -987,7 +1185,7 @@
       }
     }
   ],
-  "refresh": "30s",
+  "refresh": false,
   "schemaVersion": 25,
   "style": "dark",
   "tags": [],
@@ -1074,7 +1272,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -1093,5 +1291,5 @@
   "timezone": "",
   "title": "Serratus",
   "uid": "-jAPZ9rWzthtaoeueue",
-  "version": 4
+  "version": 14
 }

--- a/containers/serratus-scheduler-postgres-exporter/queries.yaml
+++ b/containers/serratus-scheduler-postgres-exporter/queries.yaml
@@ -83,6 +83,25 @@ pg_stat_user_tables:
     - autoanalyze_count:
         usage: "COUNTER"
         description: "Number of times this table has been analyzed by the autovacuum daemon"
+    
+pg_stat_user_indexes:
+  query: "SELECT relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch from pg_stat_user_indexes;"
+  metrics:
+    - relname:
+        usage: "LABEL"
+        description: "Name of this table"
+    - indexrelname:
+        usage: "LABEL"
+        description: "Name of this index"
+    - idx_scan:
+        usage: "COUNTER"
+        description: "Number of index scans"
+    - idx_tup_read:
+        usage: "COUNTER"
+        description: "Number of tuple reads"
+    - idx_tup_fetch:
+        usage: "COUNTER"
+        description: "Number of tuple fetches"
 
 pg_statio_user_tables:
   query: "SELECT current_database() datname, schemaname, relname, heap_blks_read, heap_blks_hit, idx_blks_read, idx_blks_hit, toast_blks_read, toast_blks_hit, tidx_blks_read, tidx_blks_hit FROM pg_statio_user_tables"
@@ -225,3 +244,15 @@ scheduler_block_state:
         usage: "GAUGE"
         description: "Number of blocks in this state"
 
+pg_relation:
+  query: "SELECT relname, pg_relation_size(C.oid) as size, pg_total_relation_size(C.oid) AS total_size FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) WHERE nspname = 'public'"
+  metrics:
+  - relname:
+      usage: LABEL
+      description: "Name of relation"
+  - size:
+      usage: "GAUGE"
+      description: "pg_relation_size()"
+  - total_size:
+      usage: "GAUGE"
+      description: "pg_relation_total_size()"

--- a/containers/serratus-scheduler/Dockerfile
+++ b/containers/serratus-scheduler/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.11
 
 RUN apk add \
         python3 postgresql-client py3-flask py3-sqlalchemy py3-gunicorn \
-        py3-prometheus-client py3-psycopg2 && \
-    pip3 install boto3 # boto3 not in 3.11
+        py3-prometheus-client py3-psycopg2 py3-gevent && \
+    pip3 install boto3 psycogreen # boto3 not in 3.11
 
 # Run Python in UTF-8 mode
 ENV FLASK_APP=flask_app

--- a/containers/serratus-scheduler/TUNING.md
+++ b/containers/serratus-scheduler/TUNING.md
@@ -1,0 +1,63 @@
+# Gunicorn and Postgres Tuning
+
+We're switching Gunicorn to async workers, which has some implications across
+the application.  It's possible that our application will be CPU-bound (parsing
+JSON), or IO-bound (waiting for Postgres), so let's make sure it behaves
+appropriately in both cases.
+
+## The app
+
+I wrote a test app with two routes.  `/io` which is clearly IO-bound:
+
+    @app.route("/io")
+    def io():
+        with db.engine.connect() as con:
+            con.execute("SELECT pg_sleep(5);")
+        return "hello there!\n"
+
+and `/cpu`, which is clearly CPU-bound:
+
+    @app.route("/cpu")
+    def cpu():
+         return str(sum(range(100000000))) # About 2 seconds on my laptop.
+
+To test configurations, I run the server using Gunicorn, and spin up 3000 curls.
+I'm intentionally overloading the server, so I expect the results to trickle in.
+Unacceptable are server crashes, invalid responses, and so on.
+
+## SQLAlchemy QueuePools
+
+Let's run gunicorn with the following settings:
+
+    worker_class = "gevent"
+    workers = 1
+
+Right away, when we run our "1000 curls", we see problems:
+
+    $ for i in $(seq 1 3000); do curl localhost:8001/io & done; time wait
+    QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.
+
+This is a problem, and it gives us some hints about how SQLAlchemy manages connections, explained very well by [http://www.javaear.com/question/57844921.html], and in more detail in the documentation: https://duckduckgo.com/?t=ffab&q=sqlalchemy+connection+pooling&atb=v143-1&ia=web
+
+To summarize, SQLAlchemy maintains a pool of open connections.  This connection pool starts at zero connections, and grows until it reaches `pool_size` (5 by default).  If all 5 connections are occupied, it creates up to `overflow` extra connections, but closes them as soon as they're returned.
+
+## CPU Load
+
+Let's run the same curl command as above, but with the `/cpu` endpoint, to see how this would handle being CPU-bound.  In this case we find that all of our CPUs are initially maxxed out, but the processes drop out, and in the end, only one process is handling the requests.  This is also a problem.
+
+## Gunicorn Worker Connections
+
+It turns out these have a common cause: gunicorn by default allows each worker to process up to 1000 requests.  https://docs.gunicorn.org/en/stable/settings.html#worker-connections
+
+This causes problems with CPU-bound loads, because a worker can pick up to 1000 jobs, but then if those jobs are CPU-heavy, it doesn't actually have the capacity to process them all in a single process.  Some of them will eventually timeout, creating stability problems.
+
+This is the same situation for IO-heavy loads.  The 15-connection limit puts a limit on the amount of throughput a process can do.  If it tries to handle 1000 requests through 15 connections, those requests can time out and fail.
+
+Let's try reducing this to a more sane value.  It should be somewhere close to the maximum number of open connections.  If it is lower, we'll be wasting connections.  If it's higher, our requests have the potential to block waiting for a connection.  In our case, we have a mix of high latency operations (merge queries) and low latency operations (align queries), which differ by around two orders of magnitude in terms response time.  I don't want the fast operations to get stuck in a queue with the slow operations, so I've set `worker_connections` less than `pool_size + overflow`.
+
+## Postgres Max Connections
+
+The last thing to tune is postgres `max_connections`.  This is fairly easy to calculate, by `worker_connections * workers`.  For a 32-CPU m5.8xlarge instance, we'll have `33 * 15 = 495` connections maximum from Flask.  Let's set this to 1000, so that we have some overhead room.
+
+I've found that just increasing `max_connections` in Postgres (version 12) works without any other steps.  I didn't need to change kernel parameters or anything complicated.
+

--- a/containers/serratus-scheduler/flask_app/__init__.py
+++ b/containers/serratus-scheduler/flask_app/__init__.py
@@ -1,5 +1,13 @@
 """Master job scheduler.  Listens for requests from workers and feeds
 them information about work that needs doing."""
+
+# Monkey patches
+from gevent import monkey
+from psycogreen.gevent import patch_psycopg
+
+monkey.patch_all()
+patch_psycopg()
+
 import os
 import json
 import subprocess

--- a/containers/serratus-scheduler/gunicorn.conf.py
+++ b/containers/serratus-scheduler/gunicorn.conf.py
@@ -2,6 +2,7 @@ import multiprocessing
 from prometheus_client import multiprocess as prom_mp
 
 workers = multiprocessing.cpu_count() * 2 + 1
+worker_class = "gevent"
 
 
 def child_exit(server, worker):

--- a/containers/serratus-scheduler/gunicorn.conf.py
+++ b/containers/serratus-scheduler/gunicorn.conf.py
@@ -17,15 +17,15 @@ workers = multiprocessing.cpu_count() + 1
 # workers.  The maximum number of requests in progress is defined by SQLAlchemy
 # QueuePool.pool_size + QueuePool.overflow (defaults 5, and 10, for a total of
 # 15 connections at a time).  This allows for the following mix under heavy load:
-#  * 1 in CPU work (eg: parsing JSON)
-#  * 9 waiting for Postgres
-worker_connections = 15
+#  * 3 in CPU work (eg: parsing JSON)
+#  * 5 waiting for Postgres
+worker_connections = 10
 
 # Due to the same, we'll need to increase the number of Postgres max_connections,
 # up to:
-#     workers * (pool_size + overflow)
-# For an m5.8xlarge, with 32vCPUs, that's (32 + 1) * (5 + 10) = 500
-# We'll use 1000 connections, for good measure.
+#     workers * min(pool_size + overflow, worker_connections)
+# For an m5.8xlarge, with 32vCPUs, that's (32 + 1) * (10) = 330
+# We'll set it to 400 connections, for good measure.
 
 
 def child_exit(server, worker):

--- a/containers/serratus-scheduler/gunicorn.conf.py
+++ b/containers/serratus-scheduler/gunicorn.conf.py
@@ -1,8 +1,31 @@
 import multiprocessing
 from prometheus_client import multiprocess as prom_mp
 
-workers = multiprocessing.cpu_count() * 2 + 1
+# Use async workers, since we spend a lot of time waiting for postgres.
 worker_class = "gevent"
+
+# With async workers, we can saturate the CPUs even when some threads are in
+# IO.  Use cpu_count() + 1 assuming there's *some* time switching threads or
+# getting data.
+workers = multiprocessing.cpu_count() + 1
+
+# The default of 1000 is *way* too high.  Just by probability some workers
+# will end up processing slower requests, and "fast" requests will get stuck
+# waiting in their SQLAlchemy QueuePools behind slow requests.  Keeping the
+# number of requests actively being processed by each worker *less than* the
+# worker's maximum number of active requests, means that jobs will go to idle
+# workers.  The maximum number of requests in progress is defined by SQLAlchemy
+# QueuePool.pool_size + QueuePool.overflow (defaults 5, and 10, for a total of
+# 15 connections at a time).  This allows for the following mix under heavy load:
+#  * 1 in CPU work (eg: parsing JSON)
+#  * 9 waiting for Postgres
+worker_connections = 15
+
+# Due to the same, we'll need to increase the number of Postgres max_connections,
+# up to:
+#     workers * (pool_size + overflow)
+# For an m5.8xlarge, with 32vCPUs, that's (32 + 1) * (5 + 10) = 500
+# We'll use 1000 connections, for good measure.
 
 
 def child_exit(server, worker):

--- a/containers/serratus-scheduler/gunicorn_pg_gevent_test.py
+++ b/containers/serratus-scheduler/gunicorn_pg_gevent_test.py
@@ -1,0 +1,26 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from psycogreen.gevent import patch_psycopg
+from gevent import monkey
+
+monkey.patch_all()
+patch_psycopg()
+
+DATABASE = "postgresql://postgres@localhost:5433/postgres"
+
+app = Flask(__name__)
+app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+db = SQLAlchemy(app)
+
+
+@app.route("/cpu")
+def cpu():
+    return str(sum(range(100000000)))
+
+
+@app.route("/io")
+def index():
+    with db.engine.connect() as con:
+        con.execute("SELECT pg_sleep(5);")
+    return "hello there!\n"

--- a/terraform/bucket/main.tf
+++ b/terraform/bucket/main.tf
@@ -4,8 +4,8 @@
 // VARIABLES ==============================================
 
 variable "prefixes" {
-  type = set(string)
-  default = []
+  type        = set(string)
+  default     = []
   description = "Prefixes to monitor"
 }
 
@@ -14,8 +14,8 @@ resource "aws_s3_bucket" "work" {
   force_destroy = true
 
   tags = {
-    "project": "serratus"
-    "component": "serratus-scheduler"
+    "project" : "serratus"
+    "component" : "serratus-scheduler"
   }
 }
 
@@ -23,13 +23,13 @@ resource "aws_s3_bucket" "work" {
 
 resource "aws_s3_bucket_metric" "full" {
   bucket = aws_s3_bucket.work.bucket
-  name = "full"
+  name   = "full"
 }
 
 resource "aws_s3_bucket_metric" "prefix" {
   for_each = var.prefixes
-  bucket = aws_s3_bucket.work.bucket
-  name = "prefix-${each.value}"
+  bucket   = aws_s3_bucket.work.bucket
+  name     = "prefix-${each.value}"
 
   filter {
     prefix = each.value

--- a/terraform/ecs_cluster/main.tf
+++ b/terraform/ecs_cluster/main.tf
@@ -93,17 +93,17 @@ resource "aws_iam_role_policy_attachment" "instance_attachment" {
 }
 
 resource aws_instance "i" {
-  ami = data.aws_ami.ecs.id
-  instance_type = var.instance_type
+  ami                                  = data.aws_ami.ecs.id
+  instance_type                        = var.instance_type
   instance_initiated_shutdown_behavior = "terminate"
   vpc_security_group_ids               = var.security_group_ids
   key_name                             = var.key_name
   iam_instance_profile                 = aws_iam_instance_profile.p.name
 
   tags = {
-    "Name": "serratus-${var.name}"
-    "project": "serratus"
-    "component": "serratus-${var.name}"
+    "Name" : "serratus-${var.name}"
+    "project" : "serratus"
+    "component" : "serratus-${var.name}"
   }
 
   user_data = <<-EOF

--- a/terraform/iam_role/main.tf
+++ b/terraform/iam_role/main.tf
@@ -6,8 +6,8 @@
 
 // VARIABLES ==============================================
 
-variable "name" { 
-  type = string
+variable "name" {
+  type        = string
   description = "Descriptive name used to identify components"
 }
 

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -100,9 +100,13 @@ module "scheduler" {
 
   security_group_ids = [aws_security_group.internal.id]
   key_name           = var.key_name
-  instance_type      = "c5.large"
+  instance_type      = "m5.large"
   dockerhub_account  = var.dockerhub_account
   scheduler_port     = var.scheduler_port
+
+  # https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
+  pg_shared_buffers  = "2GB" # 1/4 of RAM
+  pg_effective_cache = "6GB" # 3/4 of RAM
 }
 
 // Cluster monitor

--- a/terraform/main/main.tf.metal
+++ b/terraform/main/main.tf.metal
@@ -102,6 +102,10 @@ module "scheduler" {
   instance_type      = "m5.8xlarge"
   dockerhub_account  = var.dockerhub_account
   scheduler_port     = var.scheduler_port
+
+  # https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
+  pg_shared_buffers  = "32GB" # 1/4 of RAM
+  pg_effective_cache = "96GB" # 3/4 of RAM
 }
 
 // Cluster monitor

--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -49,10 +49,10 @@ data "aws_region" "current" {}
 module "ecs_cluster" {
   source = "../ecs_cluster"
 
-  name = "scheduler"
-  instance_type = var.instance_type
+  name               = "scheduler"
+  instance_type      = var.instance_type
   security_group_ids = var.security_group_ids
-  key_name = var.key_name
+  key_name           = var.key_name
 }
 
 # Give the scheduler an Elastic-IP so we can destroy and recreate it without
@@ -62,8 +62,8 @@ resource "aws_eip" "sch" {
   vpc      = true
 
   tags = {
-    "project": "serratus"
-    "component": "serratus-scheduler"
+    "project" : "serratus"
+    "component" : "serratus-scheduler"
   }
 }
 
@@ -95,36 +95,36 @@ resource "aws_cloudwatch_log_group" "scheduler" {
 
 
 resource "random_password" "pg_password" {
-  length = 16
+  length  = 16
   special = false
 }
 
 resource aws_ecs_task_definition "scheduler" {
   family = "scheduler"
   container_definitions = templatefile("../scheduler/scheduler-task-definition.json", {
-    dockerhub_account  = var.dockerhub_account
-    sched_port = var.scheduler_port,
-    aws_region = data.aws_region.current.name
-    log_group  = aws_cloudwatch_log_group.scheduler.name
-    pg_password = random_password.pg_password.result
+    dockerhub_account = var.dockerhub_account
+    sched_port        = var.scheduler_port,
+    aws_region        = data.aws_region.current.name
+    log_group         = aws_cloudwatch_log_group.scheduler.name
+    pg_password       = random_password.pg_password.result
   })
   task_role_arn = module.ecs_cluster.task_role.arn
-  network_mode = "host"
+  network_mode  = "host"
 
   volume {
     name = "postgres-data"
 
     docker_volume_configuration {
-      scope = "shared"
+      scope         = "shared"
       autoprovision = true
-      driver = "local"
+      driver        = "local"
     }
   }
 }
 
 resource aws_ecs_service "scheduler" {
-  name = "serratus-scheduler"
-  cluster = module.ecs_cluster.cluster.id
+  name            = "serratus-scheduler"
+  cluster         = module.ecs_cluster.cluster.id
   task_definition = aws_ecs_task_definition.scheduler.arn
 
   # TODO: Allow this to scale-out to many instances.

--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -31,6 +31,14 @@ variable "security_group_ids" {
   default = []
 }
 
+variable "pg_shared_buffers" {
+  type = string
+}
+
+variable "pg_effective_cache" {
+  type = string
+}
+
 data "aws_ami" "amazon_linux_2" {
   most_recent = true
   owners      = ["self"]
@@ -107,6 +115,9 @@ resource aws_ecs_task_definition "scheduler" {
     aws_region        = data.aws_region.current.name
     log_group         = aws_cloudwatch_log_group.scheduler.name
     pg_password       = random_password.pg_password.result
+
+    pg_shared_buffers  = var.pg_shared_buffers
+    pg_effective_cache = var.pg_effective_cache
   })
   task_role_arn = module.ecs_cluster.task_role.arn
   network_mode  = "host"

--- a/terraform/scheduler/scheduler-task-definition.json
+++ b/terraform/scheduler/scheduler-task-definition.json
@@ -3,7 +3,7 @@
     "name": "postgres",
     "image": "postgres:12",
     "memoryReservation": 128,
-    "essential": false,
+    "essential": true,
     "command": [
       "-c", "shared_preload_libraries=pg_stat_statements",
       "-c", "max_connections=400",
@@ -38,7 +38,7 @@
   {
     "name": "postgres-exporter",
     "image": "${dockerhub_account}/serratus-scheduler-postgres-exporter",
-    "cpu": 128,
+    "cpu": 256,
     "memoryReservation": 128,
     "environment": [
       { "name": "DATA_SOURCE_NAME", "value": "postgresql://postgres@localhost:5432/postgres?sslmode=disable" }
@@ -61,9 +61,8 @@
   {
     "name": "flask",
     "image": "${dockerhub_account}/serratus-scheduler",
-    "cpu": 256,
     "memoryReservation": 128,
-    "essential": false,
+    "essential": true,
     "portMappings": [
       {
         "containerPort": 8000,
@@ -82,7 +81,6 @@
   {
     "name": "cron",
     "image": "${dockerhub_account}/serratus-scheduler",
-    "cpu": 256,
     "memoryReservation": 128,
     "essential": false,
     "portMappings": [

--- a/terraform/scheduler/scheduler-task-definition.json
+++ b/terraform/scheduler/scheduler-task-definition.json
@@ -4,7 +4,7 @@
     "image": "postgres:12",
     "memoryReservation": 128,
     "essential": true,
-    "command": ["-c", "shared_preload_libraries=pg_stat_statements"],
+    "command": ["-c", "shared_preload_libraries=pg_stat_statements", "-c", "max_connections=1000"],
     "portMappings": [
       {
         "containerPort": 5432,

--- a/terraform/scheduler/scheduler-task-definition.json
+++ b/terraform/scheduler/scheduler-task-definition.json
@@ -3,7 +3,7 @@
     "name": "postgres",
     "image": "postgres:12",
     "memoryReservation": 128,
-    "essential": true,
+    "essential": false,
     "command": ["-c", "shared_preload_libraries=pg_stat_statements", "-c", "max_connections=1000"],
     "portMappings": [
       {
@@ -40,14 +40,22 @@
         "containerPort": 9187,
         "hostPort": 9187
       }
-    ]
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "serratus-scheduler",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "postgres-exporter"
+      }
+    }
   },
   {
     "name": "flask",
     "image": "${dockerhub_account}/serratus-scheduler",
     "cpu": 256,
     "memoryReservation": 128,
-    "essential": true,
+    "essential": false,
     "portMappings": [
       {
         "containerPort": 8000,
@@ -68,7 +76,7 @@
     "image": "${dockerhub_account}/serratus-scheduler",
     "cpu": 256,
     "memoryReservation": 128,
-    "essential": true,
+    "essential": false,
     "portMappings": [
       {
         "containerPort": 9101,

--- a/terraform/scheduler/scheduler-task-definition.json
+++ b/terraform/scheduler/scheduler-task-definition.json
@@ -4,7 +4,15 @@
     "image": "postgres:12",
     "memoryReservation": 128,
     "essential": false,
-    "command": ["-c", "shared_preload_libraries=pg_stat_statements", "-c", "max_connections=1000"],
+    "command": [
+      "-c", "shared_preload_libraries=pg_stat_statements",
+      "-c", "max_connections=400",
+      "-c", "synchronous_commit=off",
+      "-c", "log_temp_files=0",
+      "-c", "shared_buffers=${pg_shared_buffers}",
+      "-c", "effective_cache_size=${pg_effective_cache}",
+      "-c", "work_mem=32MB"
+    ],
     "portMappings": [
       {
         "containerPort": 5432,

--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -16,9 +16,9 @@ variable "spot_price" {
 }
 
 variable "volume_size" {
-  type = number
+  type        = number
   description = "Size of the root EBS volume in GB"
-  default = 8
+  default     = 8
 }
 
 variable "volume_type" {
@@ -91,7 +91,7 @@ variable "security_group_ids" {
 }
 
 variable "options" {
-  type = string
+  type        = string
   description = "Options to pass to the container"
 }
 
@@ -204,8 +204,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "s3_delete" {
-  name = "S3DeleteData-${var.image_name}"
-  role = module.iam_role.role.id
+  name  = "S3DeleteData-${var.image_name}"
+  role  = module.iam_role.role.id
   count = var.s3_delete_prefix != "" ? 1 : 0
 
   policy = <<EOF
@@ -298,7 +298,7 @@ resource "aws_launch_configuration" "worker" {
 
 // TODO: COOLDOWN POLICY NOT ATTACHED TO GROUP
 resource "aws_autoscaling_policy" "worker" {
-  name = aws_launch_configuration.worker.name
+  name                   = aws_launch_configuration.worker.name
   autoscaling_group_name = aws_autoscaling_group.worker.name
   scaling_adjustment     = 5
   adjustment_type        = "ChangeInCapacity"

--- a/terraform/worker/main.tf
+++ b/terraform/worker/main.tf
@@ -37,12 +37,6 @@ variable "scheduler" {
   type = string
 }
 
-variable "workers" {
-  type        = number
-  description = "Number of worker threads to use"
-  default     = 1
-}
-
 variable "dev_cidrs" {
   description = "Remote IP Address, for SSH, HTTP, etc access"
   type        = set(string)


### PR DESCRIPTION
A few changes to try and let the scheduler scale better:

 - Flask worker is now async (with gevent).  This allows for up to 10x the number of simultaneous queries, and should let "fast" queries bypass "slow" queries.
 - Postgres settings tuned.  I've dialed up memory settings everywhere to push the database to use that memory on the m5.8xlarge — the defaults are REALLY low.
 - Extra postgres metrics.  Now with table sizes.  If things break again we can cross-compare these metrics with memory sizes tuned above.  If a table size crosses a memory threshold and things break at the same time, that'll tell us where to look next.  There are also some counters for index usage which I hadn't noticed before, which tells us how to improve our indexes. :)

I was having some difficulty with crash looping that seemed to be unique to me.  I haven't done anything to directly fix this, but poking at values in the task definition has somewhat mitigated it.  I don't think anything there should cause problems, but if it suddenly causes problems in your setup we'll roll it back.