### PR TITLE
New Base Image added for use in Dockerfile

### DIFF
--- a/containers/serraplace/Dockerfile
+++ b/containers/serraplace/Dockerfile
@@ -1,18 +1,20 @@
-FROM ubuntu:18.04
+##### Builder Image #######
+FROM base_img_serratus:latest
 # install all the dependencies
-RUN 	apt-get update &&\
-	apt-get -y install wget git cmake build-essential zlib1g-dev gzip unzip flex bison &&\
-	wget http://eddylab.org/software/hmmer/hmmer-3.3.tar.gz&& tar xzvf hmmer-3.3.tar.gz && cd hmmer-3.3/ &&\
-	./configure && make -j4 && make install && cd easel && make install && cd ../../ &&\
-	git clone --recursive https://github.com/Pbdas/epa-ng.git &&\
-	cd epa-ng && git checkout tags/v0.3.7 && git submodule update --init --recursive && make -j4 && cp bin/epa-ng /usr/local/bin && cd - &&\
-	git clone https://github.com/lh3/seqtk.git && cd seqtk && make && cp seqtk /usr/local/bin && cd - &&\
+RUN 	apk add cmake bison flex zlib-dev && git clone --recursive https://github.com/Pbdas/epa-ng.git &&\
+	cd epa-ng && git checkout tags/v0.3.7 && git submodule update --init --recursive && make -j4 && cd - &&\
+	git clone https://github.com/lh3/seqtk.git && cd seqtk && make && cd - &&\
 	git clone --recursive https://github.com/lczech/gappa.git &&\
-	cd gappa && git checkout f05e9fe && git submodule update --init --recursive && make -j4 && cp bin/gappa /usr/local/bin && cd - &&\
-	cd gappa/libs/genesis/apps && git clone https://github.com/Pbdas/genesis-apps.git && make -j4 -C .. && cp ../bin/apps/genesis-apps/msa-merge ../bin/libgenesis.so /usr/local/bin && cd - &&\
-	mkdir -p /serratus-data/serraplace && cd /serratus-data/serraplace && wget https://serratus-public.s3.amazonaws.com/pb/serraplace/reference/refpack.tar.gz && tar xzvf refpack.tar.gz && cd -
+	cd gappa && git checkout f05e9fe && git submodule update --init --recursive && make -j4 && cd - &&\
+	cd gappa/libs/genesis/apps && git clone https://github.com/Pbdas/genesis-apps.git && make -j4 -C .. && cd -
 
+#######  Final Image #########
+
+FROM base_img_serratus:latest
 WORKDIR /home/serratus
+COPY --from=builder epa-ng/bin/epa-ng  /usr/local/bin
+COPY --from=builder seqtk/seqtk /usr/local/bin
+COPY --from=builder gappa/libs/genesis/bin/gappa gappa/libs/genesis/bin/libgenesis.so /usr/local/bin
 COPY place.sh /home/serratus/
 
 ENTRYPOINT ["/home/serratus/place.sh", "-d"]

--- a/containers/serraplace/Dockerfile_BaseImg
+++ b/containers/serraplace/Dockerfile_BaseImg
@@ -1,0 +1,7 @@
+FROM alpine:latest
+# install all the dependencies
+RUN 	apk add --update alpine-sdk && apk add wget git cmake unzip &&\
+	wget http://eddylab.org/software/hmmer/hmmer-3.3.tar.gz && tar xzvf hmmer-3.3.tar.gz && cd hmmer-3.3/ &&\
+	./configure && make -j4 && make install && cd easel && make install && cd ../../ &&\
+	mkdir -p /serratus-data/serraplace && cd /serratus-data/serraplace && wget https://serratus-public.s3.amazonaws.com/pb/serraplace/reference/refpack.tar.gz && tar xzvf refpack.tar.gz &&\
+	rm refpack.tar.gz && cd -


### PR DESCRIPTION
Step1: build Dockerfile_BaseImg
Step 2: Build Dockerfile

Currently Dockerfile is failing in last step with below error. I need to check the source code of gappa to understand furthur the root cause.

[  2%] Building CXX object libs/genesis/lib/genesis/CMakeFiles/genesis_lib_static.dir/__/__/__/__/genesis_unity_sources/lib/all.cpp.o
/gappa/build/genesis_unity_sources/lib/all.cpp: In function 'std::string genesis::utils::strerror_()':
/gappa/build/genesis_unity_sources/lib/all.cpp:36523:41: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
36523 |         std::string tmp(p, std::strlen( p ));
      |                                         ^
      |                                         |
      |                                         int
In file included from /usr/include/fortify/wchar.h:30,
                 from /usr/include/c++/10.3.1/cwchar:44,
                 from /usr/include/c++/10.3.1/bits/postypes.h:40,
                 from /usr/include/c++/10.3.1/iosfwd:40,
                 from /usr/include/c++/10.3.1/memory:74,
                 from /gappa/libs/genesis/lib/genesis/placement/sample.hpp:34,
                 from /gappa/libs/genesis/lib/genesis/placement/function/helper.hpp:34,
                 from /gappa/build/genesis_unity_sources/lib/all.cpp:33:
/usr/include/string.h:52:16: note:   initializing argument 1 of 'size_t strlen(const char*)'
   52 | size_t strlen (const char *);
      |                ^~~~~~~~~~~~
make[3]: *** [libs/genesis/lib/genesis/CMakeFiles/genesis_lib_static.dir/build.make:76: libs/genesis/lib/genesis/CMakeFiles/genesis_lib_static.dir/__/__/__/__/genesis_unity_sources/lib/all.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:141: libs/genesis/lib/genesis/CMakeFiles/genesis_lib_static.dir/all] Error 2
make[1]: *** [Makefile:91: all] Error 2
make: *** [Makefile:44: build] Error 2