### PR TITLE
Try to get `terraform plan` working with the latest Terraform

### DIFF
--- a/terraform/main/main.tf.metal
+++ b/terraform/main/main.tf.metal
@@ -42,6 +42,14 @@ variable "scheduler_port" {
   default = 8000
 }
 
+variable "metrics_ip" {
+	type = string
+}
+
+variable "output_bucket" {
+	type = string
+}
+
 // PROVIDER/AWS ##############################
 provider "aws" {
   version     = "~> 2.49"
@@ -117,6 +125,7 @@ module "monitoring" {
   scheduler_ip       = module.scheduler.private_ip
   dockerhub_account  = var.dockerhub_account
   instance_type      = "r5.2xlarge"
+	metrics_ip         = var.metrics_ip
 }
 
 // Serratus-dl
@@ -313,6 +322,7 @@ output "scheduler_dns" {
 }
 output "scheduler_pg_password" {
   value = module.scheduler.pg_password
+	sensitive = true
 }
 
 output "monitor_dns" {


### PR DESCRIPTION
Make some small changes to get `terraform plan` working with the latest Terraform 1.2.9.  To use this, you'll need to rename `main.tf.metal` to `main.tf` (overwriting the existing `main.tf`)

Reminder that `main.tf.metal` is the version that creates very expensive resources -- this will probably exceed quotas on most new AWS accounts.  _This costs money to run._

This is a draft PR.  I haven't had a chance to run this code or check my work.  Putting this here for transparency.  Use with caution. :)